### PR TITLE
Use Module API instead of internal attributes

### DIFF
--- a/t7_to_state_dict.py
+++ b/t7_to_state_dict.py
@@ -18,8 +18,8 @@ args = parser.parse_args()
 t7_model = load_lua(args.input_t7)['model']
 
 pytorch_model = getattr(models, args.model_name)()
-feature_modules = list(pytorch_model.features._modules.values())
-classifier_modules = list(pytorch_model.classifier._modules.values())
+feature_modules = list(pytorch_model.features.modules())
+classifier_modules = list(pytorch_model.classifier.modules())
 pytorch_modules = feature_modules + classifier_modules
 
 next_pytorch_idx = 0


### PR DESCRIPTION
We have `.modules()` that iterates recursively over all submodules and `.children()` that gives you an iterator over the direct children of a module.